### PR TITLE
Fix event trigger to work with Greebo.

### DIFF
--- a/action.php
+++ b/action.php
@@ -21,10 +21,8 @@ class action_plugin_rocketchatnotifier extends DokuWiki_Action_Plugin {
   }
 
   function handle_action_act_preprocess(Doku_Event $event, $param) {
-    if (isset($event->data['save'])) {
-      if ($event->data['save'] == $lang['btn_save']) {
-        $this->handle();
-      }
+    if ($event->data == 'save') {
+      $this->handle();
     }
     return;
   }


### PR DESCRIPTION
The newest version of Dokuwiki fills `$event->data` with just the event name; the old code expected this member to be an array. This change fixes the event handler.

Fixes issue #4.